### PR TITLE
feat(): added gpu restriction field in cluster status

### DIFF
--- a/pkg/controller/v1alpha1/cluster_types.go
+++ b/pkg/controller/v1alpha1/cluster_types.go
@@ -136,6 +136,14 @@ type ClusterStatus struct {
 
 	// VCPURestriction is the restriction on the cluster disabling the creation of new pods
 	VCPURestriction *VCPURestriction `json:"vCPURestriction,omitempty"`
+	GPURestriction  *GPURestriction  `json:"GPURestriction,omitempty"`
+}
+
+type GPURestriction struct {
+	// EnforceRestrictions is the flag to check if the cluster is restricted
+	EnforceRestrictions bool `json:"enforceRestrictions,omitempty"`
+	// LastUpdatedTimestamp is the timestamp when the enforcement was updated
+	LastUpdatedTimestamp metav1.Time `json:"lastUpdatedTimestamp,omitempty"`
 }
 
 type VCPURestriction struct {


### PR DESCRIPTION
#Summary
feat(): New field addition for Cluster CRD 


# Description
Added GPURestriction field in clusterStatus of Cluster CRD inorder to add enforcement realted to egs gpu licensing.

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like kubeslice-controller, worker-operator?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

